### PR TITLE
Suggest adding a build.properties file.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,2 @@
+sbt.version=0.11.2
+scala.version=2.9.1


### PR DESCRIPTION
When I tried to build socko, starting sbt failed because the sbt runner
script (https://raw.github.com/paulp/sbt-extras/master/sbt) detected the
project as needing sbt 0.11.0.  The project depends on version 0.6 of
the xsbt gpg plugin, which is only available for 0.11.2.  Adding a
project/build.properties allows the runner script to know exactly which
version of sbt is required.
