### PR TITLE
Use ActorRefFactory instead of ActorSystem in WebService

### DIFF
--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
@@ -40,12 +40,12 @@ import akka.actor.{ActorRefFactory, ActorRef, Props}
  *
  * @param config Web server configuration
  * @param routes Routes for processing requests
- * @param actorSystem Actor system that can be used to host Socko actors
+ * @param actorFactory Actor factory that can be used to create Socko actors
  */
 class WebServer(
   val config: WebServerConfig,
   val routes: PartialFunction[SockoEvent, Unit],
-  val actorSystem: ActorRefFactory) extends Logger {
+  val actorFactory: ActorRefFactory) extends Logger {
 
   require(config != null)
   config.validate()
@@ -74,10 +74,10 @@ class WebServer(
     None
   } else if (config.webLog.get.customActorPath.isEmpty) {
     // Turn on default web log writer
-    Some(actorSystem.actorOf(Props(new WebLogWriter(config.webLog.get.format))))
+    Some(actorFactory.actorOf(Props(new WebLogWriter(config.webLog.get.format))))
   } else {
     // Use custom provided web log writer
-    Some(actorSystem.actorFor(config.webLog.get.customActorPath.get))
+    Some(actorFactory.actorFor(config.webLog.get.customActorPath.get))
   }
 
   /**

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
@@ -25,9 +25,7 @@ import org.mashupbots.socko.events.SockoEvent
 import org.mashupbots.socko.infrastructure.Logger
 import org.mashupbots.socko.infrastructure.WebLogWriter
 
-import akka.actor.ActorRef
-import akka.actor.ActorSystem
-import akka.actor.Props
+import akka.actor.{ActorRefFactory, ActorRef, Props}
 
 /**
  * Socko Web Server
@@ -47,7 +45,7 @@ import akka.actor.Props
 class WebServer(
   val config: WebServerConfig,
   val routes: PartialFunction[SockoEvent, Unit],
-  val actorSystem: ActorSystem) extends Logger {
+  val actorSystem: ActorRefFactory) extends Logger {
 
   require(config != null)
   config.validate()
@@ -114,13 +112,13 @@ class WebServer(
       bootstrap.setOption("child.soLinger", config.tcp.soLinger.get)
     }
     if (config.tcp.trafficClass.isDefined) {
-      bootstrap.setOption("child.trafficClass", config.tcp.trafficClass.get);
+      bootstrap.setOption("child.trafficClass", config.tcp.trafficClass.get)
     }
     if (config.tcp.reuseAddress.isDefined) {
-      bootstrap.setOption("child.reuseAddress", config.tcp.reuseAddress.get);
+      bootstrap.setOption("child.reuseAddress", config.tcp.reuseAddress.get)
     }
     if (config.tcp.acceptBackLog.isDefined) {
-      bootstrap.setOption("child.backlog", config.tcp.acceptBackLog.get);
+      bootstrap.setOption("child.backlog", config.tcp.acceptBackLog.get)
     }
     
     bootstrap.setPipelineFactory(new PipelineFactory(this))


### PR DESCRIPTION
Replacing ActorSystem by an ActorRefFactory allow to create the WebService as a child actor (using self.context) or using an ActorSystem like it previously was.
