### PR TITLE
ReflectUtil: do not count in classes with special char when load from JAR

### DIFF
--- a/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/ReflectUtil.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/infrastructure/ReflectUtil.scala
@@ -72,7 +72,7 @@ object ReflectUtil extends Logger {
         e <- entries;
         entryName = e.getName();
         className = entryName.replace('/', '.').replace('\\', '.').replace(".class", "");
-        if (className.startsWith(packageName))
+        if (className.startsWith(packageName) && className.matches("""^[.\d\w]+$"""))
       ) yield {
         log.debug("Found class in JAR {}", className)
         className


### PR DESCRIPTION
when load from file, it only load classname with letter and digits, but
load from jar does not do this check, class with dollar will be loaded
and lead to register error

this lead to load error in my socko-rest server, and this patch could 
fix it for me
