### PR TITLE
fix Expect: 100-continue error

### DIFF
--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
@@ -60,11 +60,12 @@ class PipelineFactory(server: WebServer) extends ChannelInitializer[SocketChanne
         httpConfig.maxChunkSizeInBytes)
       pipeline.addLast("decoder", httpRequestDecoder)
 
+      pipeline.addLast("encoder", new HttpResponseEncoder())
+
       if (httpConfig.aggreateChunks) {
         pipeline.addLast("chunkAggregator", new HttpObjectAggregator(httpConfig.maxLengthInBytes))
       }
 
-      pipeline.addLast("encoder", new HttpResponseEncoder())
       pipeline.addLast("chunkWriter", new ChunkedWriteHandler())
 
       if (server.config.idleConnectionTimeout.toSeconds > 0) {


### PR DESCRIPTION
socko can't handle posts from curl version 7.30.0 greater len than 1024 without disabling http 1.1 in the client due to "http 1.1 expect 100-continue" behavior.

to reproduce, post 2k data with curl with and without the -0 "curl -0" option to disable http 1.1.

this fix comes from netty issue https://github.com/netty/netty/issues/2606 resolution
