### PR TITLE
Shutdown netty worker threads on WebServer.stop()

### DIFF
--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
@@ -120,6 +120,9 @@ class WebServer(
     Some(actorRef)
   }
 
+  val bossGroup = new NioEventLoopGroup
+  val workerGroup = new NioEventLoopGroup
+
   /**
    * Starts the server
    */
@@ -127,8 +130,6 @@ class WebServer(
     
     allChannels.clear()
 
-    val bossGroup = new NioEventLoopGroup
-    val workerGroup = new NioEventLoopGroup
     val bootstrap = new ServerBootstrap()
     .group(bossGroup, workerGroup)
     .channel(classOf[NioServerSocketChannel])
@@ -194,6 +195,9 @@ class WebServer(
     future.awaitUninterruptibly()
 
     allChannels.clear()
+
+    workerGroup.shutdownGracefully()
+    bossGroup.shutdownGracefully()
 
     log.info("Socko server '{}' stopped", config.serverName)
   }


### PR DESCRIPTION
My application was not stopping after WebServer.stop() was called. The netty event loop threads were staying alive.

Based on the Netty examples (http://netty.io/wiki/user-guide-for-4.x.html) I've changed stop() to shutdown the event loop groups.

I'm brand new to Netty and Socko so it is quite possible that this is by design but I've opened the pull request anyway.
