### PR TITLE
Removes space in link to fix it on web site

### DIFF
--- a/docs.markdown
+++ b/docs.markdown
@@ -18,9 +18,9 @@ layout: article
 
 ## Articles
 
-- [Web socket push notifications in Akka, Netty and Socko] (http://www.cakesolutions.net/teamblogs/2012/05/10/web-socket-push-notifications-in-akka-netty-and-socko/)
+- [Web socket push notifications in Akka, Netty and Socko](http://www.cakesolutions.net/teamblogs/2012/05/10/web-socket-push-notifications-in-akka-netty-and-socko/)
   by _Jan Machacek_
-- [APIs for Akka applications] (http://www.cakesolutions.net/teamblogs/2012/05/11/apis-for-akka-applications/)
+- [APIs for Akka applications](http://www.cakesolutions.net/teamblogs/2012/05/11/apis-for-akka-applications/)
   by _Jan Machacek_
   
 


### PR DESCRIPTION
Before:

<img width="961" alt="screen shot 2016-10-02 at 23 08 37" src="https://cloud.githubusercontent.com/assets/197224/19026543/30984626-88f5-11e6-88d8-0fb1e745fcd4.png">

After should have those actually linked. GFM seems to be a little more forgiving than Kramdown, or whatever jekyll is configured to use on the `gh-pages` branch.
