### PR TITLE
Add changes from jssweb-socko repo

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -176,7 +176,7 @@ object Dependency {
   val ant           = "org.apache.ant"                          % "ant"                          % "1.8.4"
   val concurrentmap = "com.googlecode.concurrentlinkedhashmap"  % "concurrentlinkedhashmap-lru"  % "1.3.2"
   val logback       = "ch.qos.logback"                          % "logback-classic"              % "1.0.9" % "runtime"
-  val netty         = "io.netty"                                % "netty-all"                    % "4.0.23.Final"
+  val netty         = "io.netty"                                % "netty-all"                    % "4.1.6.Final"
   val nextProtoNeg  = "org.eclipse.jetty.npn"                   % "npn-api"                      % "1.1.0.v20120525"
   val json4s        = "org.json4s"                              %% "json4s-native"               % "3.2.9"
   val scalatest     = "org.scalatest"                           % "scalatest_2.11"               % "2.2.1" % "test"

--- a/socko-webserver/src/main/java/org/mashupbots/socko/netty/HttpChunkedFile.java
+++ b/socko-webserver/src/main/java/org/mashupbots/socko/netty/HttpChunkedFile.java
@@ -16,6 +16,7 @@
 package org.mashupbots.socko.netty;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpContent;
@@ -157,23 +158,29 @@ public class HttpChunkedFile implements ChunkedInput<HttpContent> {
         file.close();
     }
 
+    @Deprecated
     @Override
     public HttpContent readChunk(ChannelHandlerContext ctx) throws Exception {
+        return readChunk(ctx.alloc());
+    }
+
+    @Override
+    public HttpContent readChunk(ByteBufAllocator allocator) throws Exception {
         long offset = this.offset;
         if (offset >= endOffset) {
-        	if (sentLastChunk){
-                return null;        		
-        	} else {
-        		// Send last chunk for this file
-        		sentLastChunk = true;
-        		return new DefaultLastHttpContent();
-        	}
+            if (sentLastChunk){
+                return null;
+            } else {
+                // Send last chunk for this file
+                sentLastChunk = true;
+                return new DefaultLastHttpContent();
+            }
         }
 
         int chunkSize = (int) Math.min(this.chunkSize, endOffset - offset);
         // Check if the buffer is backed by an byte array. If so we can optimize it a bit an safe a copy
 
-        ByteBuf buf = ctx.alloc().heapBuffer(chunkSize);
+        ByteBuf buf = allocator.heapBuffer(chunkSize);
         boolean release = true;
         try {
             file.readFully(buf.array(), buf.arrayOffset(), chunkSize);
@@ -186,6 +193,15 @@ public class HttpChunkedFile implements ChunkedInput<HttpContent> {
                 buf.release();
             }
         }
-        
+    }
+
+    @Override
+    public long length() {
+        return endOffset - startOffset;
+    }
+
+    @Override
+    public long progress() {
+        return offset - startOffset;
     }
 }

--- a/socko-webserver/src/main/java/org/mashupbots/socko/netty/HttpChunkedFile.java
+++ b/socko-webserver/src/main/java/org/mashupbots/socko/netty/HttpChunkedFile.java
@@ -16,7 +16,6 @@
 package org.mashupbots.socko.netty;
 
 import io.netty.buffer.ByteBuf;
-import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.FileRegion;
 import io.netty.handler.codec.http.DefaultHttpContent;

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/events/HttpResponseMessage.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/events/HttpResponseMessage.scala
@@ -127,7 +127,7 @@ case class HttpResponseMessage(event: HttpEvent) {
 
     // Headers
     HttpResponseMessage.setDateHeader(response)
-    headers.foreach { h => response.headers.set(h.name, h.value) }
+    headers.foreach { h => response.headers.add(h.name, h.value) }
 
     if (request.isKeepAlive) {
       // Add 'Content-Length' header only for a keep-alive connection.
@@ -417,7 +417,7 @@ case class HttpResponseMessage(event: HttpEvent) {
 
     // Headers
     HttpResponseMessage.setDateHeader(response)
-    this.headers.foreach { h => response.headers.set(h.name, h.value) }
+    this.headers.foreach { h => response.headers.add(h.name, h.value) }
     if (request.isKeepAlive) {
       // Add keep alive header as per HTTP 1.1 specifications
       HttpResponseMessage.setKeepAliveHeader(response, request.isKeepAlive)

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
@@ -67,7 +67,6 @@ class PipelineFactory(server: WebServer) extends ChannelInitializer[SocketChanne
         pipeline.addLast("chunkAggregator", new HttpObjectAggregator(httpConfig.maxLengthInBytes))
       }
 
-
       pipeline.addLast("chunkWriter", new ChunkedWriteHandler())
 
       if (server.config.idleConnectionTimeout.toSeconds > 0) {

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
@@ -67,13 +67,14 @@ class PipelineFactory(server: WebServer) extends ChannelInitializer[SocketChanne
         pipeline.addLast("chunkAggregator", new HttpObjectAggregator(httpConfig.maxLengthInBytes))
       }
 
-      pipeline.addLast("websocketCompression", new WebSocketServerCompressionHandler())
 
       pipeline.addLast("chunkWriter", new ChunkedWriteHandler())
 
       if (server.config.idleConnectionTimeout.toSeconds > 0) {
         pipeline.addLast("idleStateHandler", new IdleStateHandler(0, 0, server.config.idleConnectionTimeout.toSeconds.toInt))
       }
+
+      pipeline.addLast("websocketCompression", new WebSocketServerCompressionHandler())
 
       pipeline.addLast("handler", server.handler())
 

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/PipelineFactory.scala
@@ -24,6 +24,7 @@ import io.netty.channel.socket.SocketChannel
 import io.netty.handler.codec.http.HttpObjectAggregator
 import io.netty.handler.codec.http.HttpRequestDecoder
 import io.netty.handler.codec.http.HttpResponseEncoder
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler
 import io.netty.handler.logging.LoggingHandler
 import io.netty.handler.ssl.SslHandler
 import io.netty.handler.stream.ChunkedWriteHandler
@@ -65,6 +66,8 @@ class PipelineFactory(server: WebServer) extends ChannelInitializer[SocketChanne
       if (httpConfig.aggreateChunks) {
         pipeline.addLast("chunkAggregator", new HttpObjectAggregator(httpConfig.maxLengthInBytes))
       }
+
+      pipeline.addLast("websocketCompression", new WebSocketServerCompressionHandler())
 
       pipeline.addLast("chunkWriter", new ChunkedWriteHandler())
 

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/RequestHandler.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/RequestHandler.scala
@@ -311,7 +311,7 @@ class RequestHandler(server: WebServer, routes: PartialFunction[SockoEvent, Unit
     val wsFactory = new WebSocketServerHandshakerFactory(
       createWebSocketLocation(event),
       if (event.authorizedSubprotocols == "") null else event.authorizedSubprotocols,
-      false,
+      true,
       event.maxFrameSize)
     wsHandshaker = wsFactory.newHandshaker(event.nettyHttpRequest)
     if (wsHandshaker == null) {

--- a/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
+++ b/socko-webserver/src/main/scala/org/mashupbots/socko/webserver/WebServer.scala
@@ -120,6 +120,9 @@ class WebServer(
     Some(actorRef)
   }
 
+  val bossGroup = new NioEventLoopGroup
+  val workerGroup = new NioEventLoopGroup
+
   /**
    * Starts the server
    */
@@ -127,8 +130,6 @@ class WebServer(
     
     allChannels.clear()
 
-    val bossGroup = new NioEventLoopGroup
-    val workerGroup = new NioEventLoopGroup
     val bootstrap = new ServerBootstrap()
     .group(bossGroup, workerGroup)
     .channel(classOf[NioServerSocketChannel])
@@ -194,6 +195,9 @@ class WebServer(
     future.awaitUninterruptibly()
 
     allChannels.clear()
+
+	workerGroup.shutdownGracefully();
+	bossGroup.shutdownGracefully();
 
     log.info("Socko server '{}' stopped", config.serverName)
   }


### PR DESCRIPTION
Cleanup properly on shutdown, and allow multiple reponse headers.